### PR TITLE
List the provided modules in META.yml

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -7,4 +7,4 @@ copyright_year   = 2010
 
 [@AJGB]
 [AutoPrereqs]
-
+[MetaProvides::Package]


### PR DESCRIPTION
Dist::Zilla::Plugin::MetaProvides does this automatically.
